### PR TITLE
[fix]マイ検討リスト(index)の表示を楽天ブックスからの引用からデータベースの情報に修正

### DIFF
--- a/app/views/public/candidate_posts/index.html.erb
+++ b/app/views/public/candidate_posts/index.html.erb
@@ -2,16 +2,15 @@
 
 <% @candidate_posts.each do |candidate_post| %>
 <div>
-  <% RakutenWebService::Books::Book.search(isbn: candidate_post.isbn_code).each do |book| %>
-    <td><%= link_to (image_tag(book.medium_image_url)), book.item_url %></td>
+
+    <td><%= link_to (image_tag(candidate_post.book_image_url)), candidate_post.rakuten_books_url %></td>
     <td>
-      <%= book.title %><br>
-      作者：<%= book.author %>
-      出版社：<%= book.publisher_name %>
-      出版日：<%= book.sales_date %><br>
-      ISBNコード：<%= book.isbn %><br>
-      <%= book.item_caption%>
+      <%= candidate_post.title %><br>
+      作者：<%= candidate_post.author %>
+      出版社：<%= candidate_post.publisher %>
+      出版日：<%= candidate_post.date_of_publication %><br>
+      ISBNコード：<%= candidate_post.isbn_code %><br>
     </td>
-  <% end %>
+
 </div>
 <% end %>


### PR DESCRIPTION
マイ検討リスト(index)の表示を楽天ブックスからの引用からデータベースの情報に修正
理由：楽天APIからの引用とすると表示までに時間を要するため（前回のプルリクの修正漏れ）